### PR TITLE
Bugfix - Candidate Misspelling

### DIFF
--- a/src/main/java/com/zebrunner/carina/demo/gui/components/compare/CandidateBlock.java
+++ b/src/main/java/com/zebrunner/carina/demo/gui/components/compare/CandidateBlock.java
@@ -10,14 +10,14 @@ import org.testng.Assert;
 import com.qaprosoft.carina.core.foundation.webdriver.decorator.ExtendedWebElement;
 import com.qaprosoft.carina.core.gui.AbstractUIObject;
 
-public class CondidateBlock extends AbstractUIObject {
+public class CandidateBlock extends AbstractUIObject {
     @FindBy(xpath = ".//input[contains(@id, 'sSearch')]")
     private ExtendedWebElement inputField;
 
     @FindBy(xpath = "./div[contains(@class, 'autocomplete-search')]//a[not(@class)]")
     private List<ExtendedWebElement> autocompleteSearchElements;
 
-    public CondidateBlock(WebDriver driver, SearchContext searchContext) {
+    public CandidateBlock(WebDriver driver, SearchContext searchContext) {
         super(driver, searchContext);
     }
 

--- a/src/main/java/com/zebrunner/carina/demo/gui/pages/CompareModelsPage.java
+++ b/src/main/java/com/zebrunner/carina/demo/gui/pages/CompareModelsPage.java
@@ -9,7 +9,7 @@ import org.openqa.selenium.support.FindBy;
 
 import com.qaprosoft.carina.core.foundation.webdriver.decorator.ExtendedWebElement;
 import com.qaprosoft.carina.core.gui.AbstractPage;
-import com.zebrunner.carina.demo.gui.components.compare.CondidateBlock;
+import com.zebrunner.carina.demo.gui.components.compare.CandidateBlock;
 import com.zebrunner.carina.demo.gui.components.compare.ModelSpecs;
 
 public class CompareModelsPage extends AbstractPage {
@@ -17,7 +17,7 @@ public class CompareModelsPage extends AbstractPage {
     private final String comparePageUrl = "https://www.gsmarena.com/compare.php3";
 
     @FindBy(xpath = "//div[contains(@class, 'candidate-search')]")
-    private List<CondidateBlock> condidateBlocks;
+    private List<CandidateBlock> candidateBlocks;
 
     @FindBy(className = "compare-candidates")
     private ExtendedWebElement compareMenu;
@@ -30,14 +30,14 @@ public class CompareModelsPage extends AbstractPage {
     }
 
     public List<ModelSpecs> compareModels(String... models) {
-        CondidateBlock condidateBlock;
+        CandidateBlock candidateBlock;
         List<ModelSpecs> modelSpecs = new ArrayList<>();
         ModelSpecs modelSpec;
         for (int index = 0; index < models.length; index++) {
             modelSpec = new ModelSpecs();
-            condidateBlock = condidateBlocks.get(index);
-            condidateBlock.sendKeysToInputField(models[index]);
-            condidateBlock.getFirstPhone();
+            candidateBlock = candidateBlocks.get(index);
+            candidateBlock.sendKeysToInputField(models[index]);
+            candidateBlock.getFirstPhone();
             for (ModelSpecs.SpecType type : ModelSpecs.SpecType.values()) {
                 ExtendedWebElement spec = findExtendedWebElement(By.xpath(
                         String.format("//tr[.//a[text()='%s']]//td[@class='nfo'][%d]", type.getType(), index + 1)));


### PR DESCRIPTION
These changes correct a misspelling of the word "candidate" in two file locations.

The original misspelling was `condidate` instead of `candidate` where used.

**Locations**
CandidateBlock.java
CompareModelsPage.java

The changes update all uses of the old class name in the project.